### PR TITLE
change

### DIFF
--- a/AIPRTest_Tests/CrossFunctionalHelperTests.cs
+++ b/AIPRTest_Tests/CrossFunctionalHelperTests.cs
@@ -17,7 +17,7 @@ public class CrossFunctionalHelperTests
     [Test]
     // Input: "forbidden_word_here", maxLength: 30, strictMode: false
     // ValidateInputString -> fails
-    [TestCase("forbidden_word_here", 30, false, "Error: Initial validation failed.", null)]
+    [TestCase("forbidden_word_heres", 30, false, "Error: Initial validation failed.", null)]
     public void PerformComplexFormattingAndValidation_VariousInputs(string input, int maxLength, bool strictMode, string expectedTextContent, string expectedSignaturePart)
     {
         string result = CrossFunctionalHelper.PerformComplexFormattingAndValidation(input, maxLength, strictMode);


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Adjusted test input string in TestCase

- Preserved expected validation failure outcome


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CrossFunctionalHelperTests.cs</strong><dd><code>Correct forbidden word in test input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AIPRTest_Tests/CrossFunctionalHelperTests.cs

<li>Replaced “forbidden_word_here” with “forbidden_word_heres”<br> <li> Ensures initial validation failure assertion


</details>


  </td>
  <td><a href="https://github.com/skatamatic/AI_PRTest/pull/36/files#diff-8e88f77c81a6a2d3395cf4fca8e0ea30956f958e2f4a3523563a498d635e50f8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>